### PR TITLE
Fixed dependency on libssh2 in README

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,7 +16,7 @@ Here is the list of prerequisite software to run pylibssh2. The versions are
 the ones I develop with. It may work with earlier versions, but I can't
 guaranty anything.
 
-* `libssh2 <http://www.libssh2.org>`_ 1.2.1+
+* `libssh2 <http://www.libssh2.org>`_ 1.2.8+
 * `python <http://python.org/>`_ 2.6+
 
 Install the software


### PR DESCRIPTION
The version of libssh on which pylibssh2 depends has changed following ba721ccbedc743a29efe3a4921999bdc3f016ff9. This commit introduces libssh2_session_handshake which does not exists pre libssh2-1.2.8 http://www.libssh2.org/changes.html .
