### PR TITLE
scp_recv_e method added.

### DIFF
--- a/libssh2/session.py
+++ b/libssh2/session.py
@@ -154,6 +154,20 @@ class Session(object):
         """
         return Channel(self._session.scp_recv(remote_path))
 
+    def scp_recv_e(self, remote_path):
+        """
+        --writeme--
+        Gets a remote file via SCP Protocol. Returns a tuple of Channel and file size in bytes.
+
+        @param remote_path: absolute path of remote file to transfer
+        @type remote_path: str
+
+        @return: new channel opened and sb.st_size
+        @rtype: (L{Channel}, int)
+        """
+        ch,sz=self._session.scp_recv_e(remote_path)
+        return Channel(ch),sz
+
     def scp_send(self, path, mode, size):
         """
         Sends a file to remote host via SCP protocol.


### PR DESCRIPTION
scp_recv_e method added. It returns additionally the file size in bytes. Receiving binary files was not possible without knowing the amount of data to be received.
